### PR TITLE
Fix error creation when DB doesn't exist

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -577,7 +577,7 @@ module ActiveRecord
           configure_connection
         rescue ::PG::Error => error
           if error.message.include?("does not exist")
-            raise ActiveRecord::NoDatabaseError.new(error.message, error)
+            raise ActiveRecord::NoDatabaseError.new(error.message)
           else
             raise
           end


### PR DESCRIPTION
`ActiveRecord::NoDatabaseError` Signature changed in latest version, so it fails to create the corresponding error when DB connection is not possible